### PR TITLE
updates to work with jsx-2.7.1 dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {lib_dirs, ["deps"]}.
 
 {deps, [
-        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.7.0"}}},
+        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.7.1"}}},
         {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.1.2"}}}
        ]}.
 

--- a/src/ddb.erl
+++ b/src/ddb.erl
@@ -474,12 +474,12 @@ update_action('delete') -> <<"DELETE">>.
 -spec request(string(), json()) -> json_reply().
 
 request(Target, JSON) ->
-    Body = jsx:term_to_json(JSON),
+    Body = jsx:encode(JSON),
     %%ok = lager:debug("REQUEST BODY ~n~p", [Body]),
     Headers = headers(Target, Body),
     Opts = [{'response_format', 'binary'}],
     F = fun() -> ibrowse:send_req(?DDB_ENDPOINT, [{'Content-type', ?CONTENT_TYPE} | Headers], 'post', Body, Opts) end,
-    case ddb_aws:retry(F, ?MAX_RETRIES, fun jsx:json_to_term/1) of
+    case ddb_aws:retry(F, ?MAX_RETRIES, fun jsx:decode/1) of
         {'error', 'expired_token'} ->
             {ok, Key, Secret, Token} = ddb_iam:token(129600),
             ddb:credentials(Key, Secret, Token),

--- a/src/ddb_aws.erl
+++ b/src/ddb_aws.erl
@@ -76,11 +76,11 @@ retry(F, Max, N, H)
 			    {'error', H(Body)}
 		    end
 	    end;
-	{'ok', Code, _, Body} ->
-	    %%ok = lager:warning("Unexpected response (~s) ~p, retrying...", [Code, Body]),
+	{'ok', _Code, _, _Body} ->
+	    %%ok = lager:warning("Unexpected response (~s) ~p, retrying...", [_Code, _Body]),
 	    retry(F, Max, N + 1, H);
-	{'error', Error} ->
-	    %%ok = lager:debug("Got ~p retrying...", [Error]),
+	{'error', _Error} ->
+	    %%ok = lager:debug("Got ~p retrying...", [_Error]),
 	    retry(F, Max, N + 1, H)
     end.
 

--- a/src/ddb_aws.erl
+++ b/src/ddb_aws.erl
@@ -56,7 +56,7 @@ retry(F, Max, N, H)
 		    %%ok = lager:error("Got client error (~s) ~p, aborting...", [Code, Body]),
 		    {'error', H(Body)};
 		true ->
-		    JSON = jsx:json_to_term(Body),
+		    JSON = jsx:decode(Body),
 		    case proplists:get_value(<<"__type">>, JSON) of
 			<<"com.amazonaws.dynamodb.v20111205#ProvisionedThroughputExceededException">> ->
 			    %%ok = lager:warning("Got client error (~s) ~p, retrying...", [Code, Body]),


### PR DESCRIPTION
Hello - some v. minor changes to deal with updated function names in jsx, & an incremented dep version in rebar.config. Works well for me, hopefully shouldn't cause any issues.

If this is OK to merge, could we update the dependency in boss_db/rebar.config ? Would that be by creating a new tag here & reflecting it there?

Thanks,
Igor
